### PR TITLE
Fix: Dragons were dropping 0 weight scales. Fixes #29.

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -893,15 +893,18 @@ unknow_object(struct obj *obj)
 
 /* Fuzz the weight of a non-stacking object. Cluster weights around the
    object class weight, so that very heavy and very light versions of
-   an object are rarer. */
+   an object are rarer. Assumes that the obj's weight has already been
+   initialized. */
 staticfn void
 fuzz_weight(struct obj *obj) {
     int wt, orig_wt, fuzz_factor;
 
-    if (objects[obj->otyp].oc_merge) return;
-    orig_wt = (int) objects[obj->otyp].oc_weight;
+    if (objects[obj->otyp].oc_merge)
+        return;
+    orig_wt = obj->owt;
     fuzz_factor = orig_wt / 4;
-    if (!fuzz_factor) return;
+    if (!fuzz_factor)
+        return;
     wt = orig_wt + (2 * fuzz_factor) + 2 -  d(4, fuzz_factor);
     if (wt < 1)
         wt = 1;
@@ -939,7 +942,6 @@ mksobj_init(struct obj **obj, boolean artif)
         if (!rn2(10)) {
             boost_object(otmp, 0);
         }
-        fuzz_weight(otmp);
         break;
     case FOOD_CLASS:
         otmp->oeaten = 0;
@@ -1114,8 +1116,6 @@ mksobj_init(struct obj **obj, boolean artif)
             otmp->spe = rn1(5, 4);
             break;
         }
-        if (is_weptool(otmp))
-            fuzz_weight(otmp);
         break;
     case AMULET_CLASS:
         if (otmp->otyp == AMULET_OF_YENDOR)
@@ -1176,7 +1176,6 @@ mksobj_init(struct obj **obj, boolean artif)
         if (!rn2(8)) {
             boost_object(otmp, 0);
         }
-        fuzz_weight(otmp);
         break;
     case WAND_CLASS:
         if (otmp->otyp == WAN_WISHING)
@@ -1330,6 +1329,12 @@ mksobj(int otyp, boolean init, boolean artif)
         otmp = mk_artifact(otmp, (aligntyp) A_NONE, 99, FALSE);
     }
     otmp->owt = weight(otmp);
+
+    /* Fuzz weights after base weight is set,
+     * mergeable items are checked for in fuzz_weight */
+    if (otmp->oclass == WEAPON_CLASS || otmp->oclass == ARMOR_CLASS
+        || is_weptool(otmp))
+        fuzz_weight(otmp);
     return otmp;
 }
 
@@ -2042,7 +2047,7 @@ weight(struct obj *obj)
     } else if ((obj->oclass == WEAPON_CLASS || obj->oclass == ARMOR_CLASS
                 || is_weptool(obj))
                 && !objects[obj->otyp].oc_merge) {
-        return (int) obj->owt;
+        return wt;
     } else if ((obj->otyp == SKULL || obj->otyp == SKULL_HELM) && ismnum(obj->corpsenm)) {
         /* Yuck */
         return max(obj->otyp == SKULL ? 1 : 10, mons[obj->corpsenm].cwt / 50);

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -5442,7 +5442,11 @@ readobjnam(char *bp, struct obj *no_wish)
     if (d.booster && (d.otmp->oclass == WEAPON_CLASS || d.otmp->oclass == ARMOR_CLASS)) {
         boost_object(d.otmp, 0);
     }
-    d.otmp->owt = weight(d.otmp);
+    /* These items should have had their weights fuzzed - don't reset it. */
+    if (d.otmp->oclass != WEAPON_CLASS && d.otmp->oclass != ARMOR_CLASS
+        && !is_weptool(d.otmp))
+        d.otmp->owt = weight(d.otmp);
+
     if (d.very && d.otmp->otyp == HEAVY_IRON_BALL)
         d.otmp->owt += WT_IRON_BALL_INCR;
 


### PR DESCRIPTION
In mkobj.c:weight(), a small snippet was checking if for weapons and armor that didn't merge and returning obj->owt. However, the object wasn't fully initialized here so owt was always 0 for dragon scales (and potentially other objects).

After this fix, dragon scales were correctly weighing in at 40, however, another problem started where the fuzzing of weights wasn't occurring - at least for wished or items. I rearranged some of the weight fuzzing so that it should work both with random item generation and with wished for items.

A nice side note, player's starting inventory items seem to always be the same standard weight. This is probably good to discourage start scumming for optimal weights.